### PR TITLE
Allow string literals as keys in labelled statements

### DIFF
--- a/third_party/esprima/esprima.js
+++ b/third_party/esprima/esprima.js
@@ -74,6 +74,7 @@
         ExpressionStatement: 'ExpressionStatement',
         Identifier: 'Identifier',
         Literal: 'Literal',
+        StringLiteral: 'StringLiteral',
         LabeledStatement: 'LabeledStatement',
         LogicalExpression: 'LogicalExpression',
         MemberExpression: 'MemberExpression',
@@ -536,6 +537,7 @@
     function expect(value) {
         var token = lex();
         if (token.type !== Token.Punctuator || token.value !== value) {
+      console.log('hello', value);
             throwUnexpected(token);
         }
     }
@@ -674,7 +676,9 @@
 
         if (type === Token.Identifier) {
             expr = delegate.createIdentifier(lex().value);
-        } else if (type === Token.StringLiteral || type === Token.NumericLiteral) {
+        } else if (type === Token.StringLiteral) {
+            expr = delegate.createStringLiteral(lex());
+        } else if (type === Token.NumericLiteral) {
             expr = delegate.createLiteral(lex());
         } else if (type === Token.Keyword) {
             if (matchKeyword('this')) {
@@ -986,7 +990,7 @@
                 parseInExpression(expr);
             } else if (match('|')) {
                 parseFilters(expr);
-            } else if (expr.type === Syntax.Identifier && match(':')) {
+            } else if (match(':')) {
                 parseLabelledExpressions(expr);
             } else {
                 delegate.createTopLevel(expr);
@@ -1005,9 +1009,10 @@
 
     // LabelExpression ::
     //   Identifier ":" Expression
+    //   StringLiteral ":" Expression
 
     function parseLabelledExpressions(expr) {
-        var label = expr.name;
+        var label = expr;
         expect(':');
 
         expr = parseExpression();
@@ -1015,8 +1020,9 @@
 
         consumeSemicolon();
 
-        while (lookahead.type === Token.Identifier) {
-            label = lex().value;
+        while (lookahead.type === Token.Identifier ||
+               lookahead.type === Token.StringLiteral) {
+            label = parseExpression();
             expect(':');
             expr = parseExpression();
             delegate.createLabeledStatement(label, expr);


### PR DESCRIPTION
As referenced in a comment by rafaelw, the current
implementation of labelled statements restricts the "key"
values to JS identifiers, which are more restricted than
CSS identifiers.

This PR allows string literals as well as identifiers in
labelled statements.

Things to note:
- I futzed with the modified esprima parser. I figured
  that was ok, since it was already being futzed with.
- With this PR, it's not true that polymer expressions
  are a "strict subset" of JS. However, labelled statements
  were being rather abused, so I'm hoping that's not too
  much of an issue, as this would be useful for me.
