### PR TITLE
Treat numbers as numbers in expressions

### DIFF
--- a/src/polymer-expressions.js
+++ b/src/polymer-expressions.js
@@ -585,13 +585,20 @@
     }
   }
 
-  function isLiteralExpression(name) {
-    switch (name) {
+  function isLiteralExpression(pathString) {
+    switch (pathString) {
+      case '':
+        return false;
+
       case 'false':
       case 'null':
       case 'true':
         return true;
     }
+
+    if (!isNaN(Number(pathString)))
+      return true;
+
     return false;
   };
 
@@ -638,20 +645,17 @@
         return prepareEventBinding(path, name, this);
       }
 
-      if (path.valid) {
+      if (!isLiteralExpression(pathString) && path.valid) {
         if (path.length == 1) {
-          if (!isLiteralExpression(path[0])) {
-            return function(model, node, oneTime) {
-              if (oneTime)
-                return path.getValueFrom(model);
+          return function(model, node, oneTime) {
+            if (oneTime)
+              return path.getValueFrom(model);
 
-              var scope = findScope(model, path[0]);
-              return new PathObserver(scope, path);
-            };
-          }
-        } else {
-          return; // bail out early if pathString is simple path.
+            var scope = findScope(model, path[0]);
+            return new PathObserver(scope, path);
+          };
         }
+        return; // bail out early if pathString is simple path.
       }
 
       return prepareBinding(pathString, name, node, this);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1854,7 +1854,7 @@ suite('PolymerExpressions', function() {
   });
 
   // https://github.com/Polymer/polymer-expressions/issues/24
-  test('issue-24', function(done) {
+  test('issue-24 - 1', function(done) {
     var div = createTestHtml(
         '<template id="t" bind if="{{ true }}">' +
           '<span>{{ b }}</span>' +
@@ -1915,6 +1915,25 @@ suite('PolymerExpressions', function() {
 
   test('issue-24 - 4', function(done) {
     var div = createTestHtml(
+        '<template id="t" bind if="{{ 0 }}">' +
+          '<span>{{ b }}</span>' +
+        '</template>');
+
+    var model = {
+      b: 'hi',
+      0: true
+    };
+
+    recursivelySetTemplateModel(div, model);
+
+    then(function() {
+      assert.equal(div.childNodes.length, 1);
+      done();
+    });
+  });
+
+  test('issue-24 - 5', function(done) {
+    var div = createTestHtml(
         '<template id="t" bind>' +
           '<span>{{ true }}</span>' +
         '</template>');
@@ -1930,4 +1949,45 @@ suite('PolymerExpressions', function() {
       done();
     });
   });
+
+  test('issue-24 - 6', function(done) {
+    var div = createTestHtml(
+        '<template id="t" bind>' +
+          '<span>{{ 111 }}</span>' +
+        '</template>');
+
+    var model = {111: 222};
+
+    recursivelySetTemplateModel(div, model);
+
+    then(function() {
+      var target = div.childNodes[1];
+      assert.equal(div.childNodes.length, 2);
+      assert.equal(target.textContent, '111');
+      done();
+    });
+  });
+
+  test('issue-24 - 7', function(done) {
+    var div = createTestHtml(
+        '<template id="t" bind>' +
+          '<span>{{ 1.2 }}</span>' +
+        '</template>');
+
+    var model = {
+      1: {
+        2: 3
+      }
+    };
+
+    recursivelySetTemplateModel(div, model);
+
+    then(function() {
+      var target = div.childNodes[1];
+      assert.equal(div.childNodes.length, 2);
+      assert.equal(target.textContent, '1.2');
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
This is is revert of the following two reverts
41155259edd18ef56a88d9b05370292bb9c79a38
d03bd9b68a0a0cff068eac28dbd7292e9ab5774f

The original commit had an issue where '' was treated as 0.
