### PR TITLE
Fix issue with dynamic deps in obj[key]

### DIFF
--- a/src/polymer-expressions.js
+++ b/src/polymer-expressions.js
@@ -8,25 +8,6 @@
 (function (global) {
   'use strict';
 
-  // JScript does not have __proto__. We wrap all object literals with
-  // createObject which uses Object.create, Object.defineProperty and
-  // Object.getOwnPropertyDescriptor to create a new object that does the exact
-  // same thing. The main downside to this solution is that we have to extract
-  // all those property descriptors for IE.
-  var createObject = ('__proto__' in {}) ?
-      function(obj) { return obj; } :
-      function(obj) {
-        var proto = obj.__proto__;
-        if (!proto)
-          return obj;
-        var newObject = Object.create(proto);
-        Object.getOwnPropertyNames(obj).forEach(function(name) {
-          Object.defineProperty(newObject, name,
-                               Object.getOwnPropertyDescriptor(obj, name));
-        });
-        return newObject;
-      };
-
   function prepareBinding(expressionText, name, node, filterRegistry) {
     var expression;
     try {
@@ -125,11 +106,12 @@
       property = new IdentPath(property.value);
     }
 
-    this.dynamicDeps = typeof object == 'function' || object.dynamic;
-
     this.dynamic = typeof property == 'function' ||
                    property.dynamic ||
                    accessor == '[';
+
+    this.dynamicDeps = this.dynamic ||
+                       typeof object == 'function' || object.dynamic;
 
     this.simplePath =
         !this.dynamic &&

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1841,8 +1841,8 @@ suite('PolymerExpressions', function() {
   test('Dynamic deps path expressions', function() {
     assert.isFalse(getExpression_('a + b').dynamicDeps);
     assert.isFalse(getExpression_('a + b > 3 + hello["kitty"]').dynamicDeps);
-    assert.isFalse(getExpression_('a[a.b]').dynamicDeps);
-    assert.isFalse(getExpression_('a[a.b] + d[e]').dynamicDeps);
+    assert.isTrue(getExpression_('a[a.b]').dynamicDeps);
+    assert.isTrue(getExpression_('a[a.b] + d[e]').dynamicDeps);
     assert.isFalse(getExpression_('a[0].c').dynamicDeps);
     assert.isFalse(getExpression_('a[1][0]').dynamicDeps);
 
@@ -1986,6 +1986,90 @@ suite('PolymerExpressions', function() {
       var target = div.childNodes[1];
       assert.equal(div.childNodes.length, 2);
       assert.equal(target.textContent, '1.2');
+      done();
+    });
+  });
+
+  test('issue-29 - 1', function(done) {
+    var div = createTestHtml(
+        '<template id="t" bind>' +
+          '{{ items[index] }}' +
+        '</template>');
+
+    var model = {
+      index: 0,
+      items: [1, 2]
+    };
+
+    recursivelySetTemplateModel(div, model);
+
+    then(function() {
+      var target = div.childNodes[1];
+      assert.equal(target.textContent, '1');
+      model.index = 1;
+    }).then(function() {
+      var target = div.childNodes[1];
+      assert.equal(target.textContent, '2');
+      model.items[1] = 3;
+    }).then(function() {
+      var target = div.childNodes[1];
+      assert.equal(target.textContent, '3');
+      done();
+    });
+  });
+
+  test('issue-29 - 2', function(done) {
+    var div = createTestHtml(
+        '<template id="t" bind>' +
+          '{{ index }} - {{ items[index] }}' +
+        '</template>');
+
+    var model = {
+      index: 0,
+      items: [1, 2]
+    };
+
+    recursivelySetTemplateModel(div, model);
+
+    then(function() {
+      var target = div.childNodes[1];
+      assert.equal(target.textContent, '0 - 1');
+      model.index++;
+    }).then(function() {
+      var target = div.childNodes[1];
+      assert.equal(target.textContent, '1 - 2');
+      model.items[1] = 3;
+    }).then(function() {
+      var target = div.childNodes[1];
+      assert.equal(target.textContent, '1 - 3');
+      done();
+    });
+  });
+
+  test('issue-29 - 3', function(done) {
+    var div = createTestHtml(
+        '<template id="t" bind="{{items[index] as item}}">' +
+          '{{ index }} - {{ item }}' +
+        '</template>');
+
+    var model = {
+      index: 0,
+      items: [1, 2]
+    };
+
+    recursivelySetTemplateModel(div, model);
+
+    then(function() {
+      var target = div.childNodes[1];
+      assert.equal(target.textContent, '0 - 1');
+      model.index++;
+    }).then(function() {
+      var target = div.childNodes[1];
+      assert.equal(target.textContent, '1 - 2');
+      model.items[1] = 3;
+    }).then(function() {
+      var target = div.childNodes[1];
+      assert.equal(target.textContent, '1 - 3');
       done();
     });
   });


### PR DESCRIPTION
The expression `object[key]` has dynamic deps because when `key`
is 'abc', the value of `object.abc` needs to be observed.

Fixes #29
