### PR TITLE
make test not depend on date formatting, fixes #43

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -127,6 +127,14 @@ suite('PolymerExpressions', function() {
     });
   }
 
+  function objToString(str) {
+    return {
+      toString: function() {
+        return str;
+      }
+    };
+  }
+
   test('ClassName Singular', function(done) {
     var div = createTestHtml(
         '<template bind><div class="{{ {foo: bar} | tokenList }}">' +
@@ -1141,14 +1149,14 @@ suite('PolymerExpressions', function() {
         'Tue Jul 08 2014 12:00:00 GMT-0700 (PDT)': 'bar',
         'Wed Jul 09 2014 12:00:00 GMT-0700 (PDT)': 'baz'
       },
-      dateObj: new Date('Tue Jul 08 2014 12:00:00 GMT-0700 (PDT)')
+      dateObj: objToString('Tue Jul 08 2014 12:00:00 GMT-0700 (PDT)')
     };
 
     recursivelySetTemplateModel(div, model);
 
     then(function() {
       assert.equal('bar', div.childNodes[1].getAttribute('foo'));
-      model.dateObj = new Date('Wed Jul 09 2014 12:00:00 GMT-0700 (PDT)');
+      model.dateObj = objToString('Wed Jul 09 2014 12:00:00 GMT-0700 (PDT)');
 
     }).then(function() {
       assert.equal('baz', div.childNodes[1].getAttribute('foo'));
@@ -1167,7 +1175,7 @@ suite('PolymerExpressions', function() {
       myObj: {
         'Tue Jul 08 2014 12:00:00 GMT-0700 (PDT)': 'bar',
       },
-      dateObj: new Date('Tue Jul 08 2014 12:00:00 GMT-0700 (PDT)')
+      dateObj: objToString('Tue Jul 08 2014 12:00:00 GMT-0700 (PDT)')
     };
 
     recursivelySetTemplateModel(div, model);


### PR DESCRIPTION
@sorvell @rafaelw ... I went for minimal change here, but we could switch away from date strings to other generic strings. I also debated renaming "dateObj" vs just leaving it... let me know if you have a preference, otherwise I can just merge this. :)
