### PR TITLE
Allow filters to express implicit dependencies

### DIFF
--- a/src/polymer-expressions.js
+++ b/src/polymer-expressions.js
@@ -213,6 +213,11 @@
         fn = fn.toDOM;
       }
 
+      var extraDepsFn = fn.extraDeps;
+      if (fn.filter) {
+        fn = fn.filter;
+      }
+
       if (typeof fn != 'function') {
         console.error('Cannot find function or filter: ' + this.name);
         return;
@@ -221,6 +226,17 @@
       var args = initialArgs || [];
       for (var i = 0; i < this.args.length; i++) {
         args.push(getFn(this.args[i])(model, observer, filterRegistry));
+      }
+
+      if (observer && extraDepsFn) {
+        var deps = extraDepsFn.apply(context, args);
+        for (var i = 0; i < deps.length; i++) {
+          if (Array.isArray(deps[i])) {
+            observer.addPath(deps[i][0], deps[i][1]);
+          } else {
+            observer.addObserver(deps[i]);
+          }
+        }
       }
 
       return fn.apply(context, args);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -133,6 +133,14 @@ suite('PolymerExpressions', function() {
         copy.sort();
         return copy;
       };
+      delegate.fetch = {
+        filter: function(obj, key) {
+          return obj[key];
+        },
+        extraDeps: function(obj, key) {
+          return [[obj, key]];
+        }
+      };
 
       template.bindingDelegate = delegate;
       template.model = model;
@@ -1508,6 +1516,32 @@ suite('PolymerExpressions', function() {
       assert.equal(errors[0][0],
                    'Invalid expression syntax: bar | upperCase + 42');
 
+      done();
+    });
+  });
+
+  test('filters with extraDeps', function(done) {
+    var div = createTestHtml(
+        '<template bind>' +
+          '{{ fetch(foo, "bar") }}' +
+        '</template>');
+
+    var model = {
+      foo: {
+        bar: 123
+      }
+    };
+
+    recursivelySetTemplateModel(div, model);
+
+    then(function() {
+      assert.equal('123', div.childNodes[1].textContent);
+      model.foo.bar = 27;
+    }).then(function() {
+      assert.equal('27', div.childNodes[1].textContent);
+      model.foo.bar = 300;
+    }).then(function() {
+      assert.equal('300', div.childNodes[1].textContent);
       done();
     });
   });


### PR DESCRIPTION
``` js
myFilter = {
  filter:    ... // The filter function.
  extraDeps: ... // A function that returns an array of observers.
};
```

An example of where I'm using it: https://github.com/Polymore/more-routing/blob/master/polymer-expressions.html#L25-33
